### PR TITLE
#9 make the DCAT variants configurable

### DIFF
--- a/application_profiles/AP_NL30/mapping/dcat-root.properties
+++ b/application_profiles/AP_NL30/mapping/dcat-root.properties
@@ -5,6 +5,12 @@
 
 ### Global Behavior
 dcat.trace.enabled = false
+dcat.format.turtle.availableToUsers = true;
+dcat.format.turtle.harvestable = true;
+dcat.format.rdfXml.availableToUsers = true;
+dcat.format.rdfXml.harvestable = true;
+dcat.format.jsonLd.availableToUsers = true;
+dcat.format.jsonLd.harvestable = true;
 
 ### Prefixes
 prefix.dcat   = http://www.w3.org/ns/dcat#

--- a/application_profiles/lightweight/mapping/dcat-root.properties
+++ b/application_profiles/lightweight/mapping/dcat-root.properties
@@ -1,5 +1,11 @@
 
 dcat.trace.enabled = false
+dcat.format.turtle.availableToUsers = true;
+dcat.format.turtle.harvestable = true;
+dcat.format.rdfXml.availableToUsers = true;
+dcat.format.rdfXml.harvestable = true;
+dcat.format.jsonLd.availableToUsers = true;
+dcat.format.jsonLd.harvestable = true;
 
 prefix.dcat   = http://www.w3.org/ns/dcat#
 prefix.dct    = http://purl.org/dc/terms/

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
 
               <!-- Merge services + prevent including your own module-info.class -->
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
               </transformers>
 
               <!-- Exclude JPMS descriptors from all shaded dependencies (incl. multi-release JARs) -->
@@ -279,7 +279,6 @@
                   <excludes>
                     <exclude>module-info.class</exclude>
                     <exclude>META-INF/versions/**/module-info.class</exclude>
-                    <!-- Keep your earlier signature/resource cleanup -->
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
@@ -307,7 +306,9 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>
-            <goals><goal>properties</goal></goals>
+            <goals>
+              <goal>properties</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -318,7 +319,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <!-- Use the resolved mockito-core jar as the agent -->
-          <argLine>-javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>        </configuration>
+          <argLine>-javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
+        </configuration>
       </plugin>
 
     </plugins>

--- a/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterBase.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterBase.java
@@ -60,14 +60,16 @@ public abstract class Dcat3ExporterBase implements Exporter {
         }
     }
 
-    @Override
     public Boolean isHarvestable() {
-        return true;
+        return root.formats().containsKey(getConfigurationKey())
+                ? root.formats().get(getConfigurationKey()).harvestable()
+                : false;
     }
 
-    @Override
     public Boolean isAvailableToUsers() {
-        return true;
+        return root.formats().containsKey(getConfigurationKey())
+                ? root.formats().get(getConfigurationKey()).availableToUsers()
+                : false;
     }
 
     /** The MIME type advertised by this exporter. */
@@ -75,6 +77,9 @@ public abstract class Dcat3ExporterBase implements Exporter {
 
     /** The Jena writer name (e.g. "TURTLE", "JSON-LD", "RDF/XML"). */
     protected abstract String getJenaWriterName();
+
+    /** The key in the configuration * */
+    protected abstract String getConfigurationKey();
 
     @Override
     public String getMediaType() {

--- a/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterJsonLd.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterJsonLd.java
@@ -28,4 +28,9 @@ public class Dcat3ExporterJsonLd extends Dcat3ExporterBase {
     protected String getJenaWriterName() {
         return "JSON-LD";
     }
+
+    @Override
+    protected String getConfigurationKey() {
+        return "jsonLd";
+    }
 }

--- a/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterRdfXml.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterRdfXml.java
@@ -28,4 +28,9 @@ public class Dcat3ExporterRdfXml extends Dcat3ExporterBase {
     protected String getJenaWriterName() {
         return "RDF/XML";
     }
+
+    @Override
+    protected String getConfigurationKey() {
+        return "rdfXml";
+    }
 }

--- a/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterTurtle.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterTurtle.java
@@ -28,4 +28,9 @@ public class Dcat3ExporterTurtle extends Dcat3ExporterBase {
     protected String getJenaWriterName() {
         return "TURTLE";
     }
+
+    @Override
+    protected String getConfigurationKey() {
+        return "turtle";
+    }
 }

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoader.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoader.java
@@ -3,6 +3,7 @@ package io.gdcc.spi.export.dcat3.config.loader;
 import static io.gdcc.spi.export.dcat3.config.loader.FileResolver.resolveFile;
 
 import io.gdcc.spi.export.dcat3.config.model.Element;
+import io.gdcc.spi.export.dcat3.config.model.FormatFlags;
 import io.gdcc.spi.export.dcat3.config.model.Relation;
 import io.gdcc.spi.export.dcat3.config.model.RootConfig;
 import java.io.IOException;
@@ -10,9 +11,11 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -21,6 +24,10 @@ public final class RootConfigLoader {
     private static final Pattern ELEMENT_ID_PATTERN = Pattern.compile("^element\\.([^.]+)\\.id$");
     private static final Pattern RELATION_PREDICATE_PATTERN =
             Pattern.compile("^relation\\.([^.]+)\\.predicate$");
+
+    // NEW: dcat.format.<format>.<flag>, where flag ∈ {availableToUsers, harvestable}
+    private static final Pattern FORMAT_FLAG_PATTERN =
+            Pattern.compile("^dcat\\.format\\.([^.]+)\\.(availableToUsers|harvestable)$");
 
     private RootConfigLoader() {}
 
@@ -39,11 +46,13 @@ public final class RootConfigLoader {
                             + SYS_PROP
                             + "' not set; please provide a path to dcat-root.properties");
         }
+
         FileResolver.ResolvedFile resolved = resolveFile(null, rootProperty);
         Properties properties = new Properties();
         try (InputStream closeMe = resolved.in()) {
             properties.load(closeMe);
         }
+
         Path baseDir = resolved.baseDir(); // may be null when loaded from classpath
         return parse(properties, baseDir);
     }
@@ -88,6 +97,65 @@ public final class RootConfigLoader {
             relations.add(relation);
         }
 
-        return new RootConfig(trace, prefixes, elements, relations, baseDir);
+        // NEW: dcat.format.<format>.<flag> -> defaults TRUE on absence
+        Map<String, FormatFlags> formats = parseFormats(properties);
+
+        return new RootConfig(trace, prefixes, elements, relations, formats, baseDir);
+    }
+
+    /** Parse dcat.format.* flags, defaulting to TRUE when a flag is absent. */
+    private static Map<String, FormatFlags> parseFormats(Properties properties) {
+        Map<String, FormatFlags> result = new LinkedHashMap<>();
+
+        // First pass: discover all <format> names present in any dcat.format.* key
+        // and collect explicit values when present.
+        Map<String, Boolean> availableToUsers = new LinkedHashMap<>();
+        Map<String, Boolean> harvestable = new LinkedHashMap<>();
+
+        for (String key : properties.stringPropertyNames()) {
+            Matcher matcher = FORMAT_FLAG_PATTERN.matcher(key);
+            if (!matcher.matches()) continue;
+
+            String format = matcher.group(1);
+            String flag = matcher.group(2);
+            String raw = properties.getProperty(key);
+
+            boolean value = safeBoolean(raw, true); // parse robustly; default TRUE if missing
+            if ("availableToUsers".equals(flag)) {
+                availableToUsers.put(format, value);
+            } else {
+                harvestable.put(format, value);
+            }
+        }
+
+        // Second pass: assemble FormatFlags for each discovered format.
+        // Even if a format appears only in one flag, the other flag defaults to TRUE.
+        // Also: if NO keys exist for a format at all, we won’t invent formats.
+        // Formats are defined implicitly by the presence of any dcat.format.<format>.* key in the
+        // file.
+        for (String format : unionKeys(availableToUsers, harvestable)) {
+            boolean a = availableToUsers.getOrDefault(format, true);
+            boolean h = harvestable.getOrDefault(format, true);
+            result.put(format, new FormatFlags(a, h));
+        }
+
+        return result;
+    }
+
+    /**
+     * Robust boolean parsing: - null -> defaultValue - trims whitespace - ignores a trailing
+     * semicolon (e.g., "true;") - uses Boolean.parseBoolean on the cleaned token
+     */
+    private static boolean safeBoolean(String raw, boolean defaultValue) {
+        if (raw == null) return defaultValue;
+        String cleaned = raw.trim();
+        if (cleaned.endsWith(";")) cleaned = cleaned.substring(0, cleaned.length() - 1).trim();
+        return Boolean.parseBoolean(cleaned);
+    }
+
+    private static <T> java.util.Set<T> unionKeys(Map<T, ?> a, Map<T, ?> b) {
+        Set<T> s = new LinkedHashSet<>(a.keySet());
+        s.addAll(b.keySet());
+        return s;
     }
 }

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/model/FormatFlags.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/model/FormatFlags.java
@@ -1,0 +1,3 @@
+package io.gdcc.spi.export.dcat3.config.model;
+
+public record FormatFlags(boolean availableToUsers, boolean harvestable) {}

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/model/RootConfig.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/model/RootConfig.java
@@ -12,4 +12,5 @@ public record RootConfig(
         Map<String, String> prefixes,
         List<Element> elements,
         List<Relation> relations,
+        Map<String, FormatFlags> formats,
         Path baseDir) {}

--- a/src/test/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoaderTest.java
+++ b/src/test/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoaderTest.java
@@ -4,6 +4,7 @@ import static io.gdcc.spi.export.dcat3.config.loader.FileResolver.resolveElement
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.gdcc.spi.export.dcat3.config.model.FormatFlags;
 import io.gdcc.spi.export.dcat3.config.model.ResourceConfig;
 import io.gdcc.spi.export.dcat3.config.model.RootConfig;
 import io.gdcc.spi.export.dcat3.config.model.ValueSource;
@@ -177,6 +178,113 @@ public class RootConfigLoaderTest {
         assertThatThrownBy(RootConfigLoader::load)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(RootConfigLoader.SYS_PROP);
+    }
+
+    @Test
+    void parses_dcat_format_flags_with_semicolons_and_defaults_true() throws Exception {
+        // Arrange
+        Path rootFile = temp.resolve("dcat-root.properties");
+        Files.writeString(
+                rootFile,
+                """
+            dcat.trace.enabled = false
+            # formats: mix van expliciet en impliciet, met trailing ';'
+            dcat.format.turtle.availableToUsers = true;
+            # harvestable voor turtle ontbreekt -> default TRUE
+
+            dcat.format.rdfXml.harvestable = true;
+            # availableToUsers voor rdfXml ontbreekt -> default TRUE
+
+            # jsonLd heeft beide flags expliciet (met ';')
+            dcat.format.jsonLd.availableToUsers = true;
+            dcat.format.jsonLd.harvestable = true;
+
+            # minimaal 1 element is nodig om parse-pad gelijk te houden
+            element.catalog.id = catalog
+            element.catalog.type = dcat:Catalog
+            element.catalog.file = dcat-catalog.properties
+            """);
+        // dummy element file
+        Files.writeString(
+                temp.resolve("dcat-catalog.properties"),
+                "subject.iri.const = https://example.org/cat");
+
+        System.setProperty(RootConfigLoader.SYS_PROP, rootFile.toString());
+
+        // Act
+        RootConfig rootConfig = RootConfigLoader.load();
+
+        // Assert
+        assertThat(rootConfig.formats()).as("Format-section must be present").isNotNull();
+        assertThat(rootConfig.formats().keySet())
+                .containsExactlyInAnyOrder("turtle", "rdfXml", "jsonLd");
+
+        FormatFlags turtle = rootConfig.formats().get("turtle");
+        assertThat(turtle.availableToUsers()).isTrue(); // explicit 'true;'
+        assertThat(turtle.harvestable()).isTrue(); // missing -> TRUE default
+
+        FormatFlags rdfXml = rootConfig.formats().get("rdfXml");
+        assertThat(rdfXml.harvestable()).isTrue(); // explicit 'true;'
+        assertThat(rdfXml.availableToUsers()).isTrue(); // missing -> TRUE default
+
+        FormatFlags jsonLd = rootConfig.formats().get("jsonLd");
+        assertThat(jsonLd.availableToUsers()).isTrue(); // explicit 'true;'
+        assertThat(jsonLd.harvestable()).isTrue(); // missing 'true;'
+    }
+
+    @Test
+    void when_no_dcat_format_keys_formats_map_is_empty() throws Exception {
+        // Arrange
+        Path rootFile = temp.resolve("dcat-root-no-formats.properties");
+        Files.writeString(
+                rootFile,
+                """
+            dcat.trace.enabled = true
+            prefix.dcat = http://www.w3.org/ns/dcat#
+            element.catalog.id = catalog
+            element.catalog.type = dcat:Catalog
+            element.catalog.file = dcat-catalog.properties
+            """);
+        Files.writeString(
+                temp.resolve("dcat-catalog.properties"),
+                "subject.iri.const = https://example.org/cat2");
+        System.setProperty(RootConfigLoader.SYS_PROP, rootFile.toString());
+
+        // Act
+        RootConfig rootConfig = RootConfigLoader.load();
+
+        // Assert
+        assertThat(rootConfig.formats()).isNotNull();
+        assertThat(rootConfig.formats()).isEmpty(); // no dcat.format.* => empty map
+    }
+
+    @Test
+    void partial_definition_missing_flag_defaults_to_true() throws Exception {
+        // Arrange
+        Path rootFile = temp.resolve("dcat-root-partial.properties");
+        Files.writeString(
+                rootFile,
+                """
+            # Only 'availableToUsers' is defined; 'harvestable' is missing and must be TRUE
+            dcat.format.csv.availableToUsers = false
+            # This also tests that FALSE is correctly read, while the missing flag defaults to TRUE.
+            element.catalog.id = catalog
+            element.catalog.type = dcat:Catalog
+            element.catalog.file = dcat-catalog.properties
+            """);
+        Files.writeString(
+                temp.resolve("dcat-catalog.properties"),
+                "subject.iri.const = https://example.org/cat3");
+        System.setProperty(RootConfigLoader.SYS_PROP, rootFile.toString());
+
+        // Act
+        RootConfig rootConfig = RootConfigLoader.load();
+
+        // Assert
+        assertThat(rootConfig.formats().keySet()).containsExactly("csv");
+        FormatFlags csv = rootConfig.formats().get("csv");
+        assertThat(csv.availableToUsers()).isFalse(); // explicit false
+        assertThat(csv.harvestable()).isTrue(); // missing -> TRUE default
     }
 
     // --- helpers ---

--- a/src/test/java/io/gdcc/spi/export/dcat3/config/validate/ValidationUtilTest.java
+++ b/src/test/java/io/gdcc/spi/export/dcat3/config/validate/ValidationUtilTest.java
@@ -16,12 +16,16 @@ class ValidationUtilTest {
     // - quoted empty ('') => empty string
     // - 'null' token converted to Java null via nullValues
     // spotless:off
-    @CsvSource( value = { "null, true",   // null -> blank
-        "'', true",     // empty string -> blank
-        "' ', true",    // space -> blank
-        "'\t', true",   // tab -> blank (real TAB char between quotes)
-        "' a ', false", // just a character
-        "'0', false" }, nullValues = { "null" } )
+    @CsvSource(
+            value = {
+                "null, true", // null -> blank
+                "'', true", // empty string -> blank
+                "' ', true", // space -> blank
+                "'\t', true", // tab -> blank (real TAB char between quotes)
+                "' a ', false", // just a character
+                "'0', false"
+            },
+            nullValues = {"null"})
     // spotless:on
     @DisplayName("isBlank should consider null/empty/whitespace as blank")
     void isBlank_cases(String input, boolean expected) {
@@ -30,12 +34,16 @@ class ValidationUtilTest {
 
     @ParameterizedTest(name = "hasText('{0}') => {1}")
     // spotless:off
-    @CsvSource( value = { "null, false",  // null -> no text
-        "'', false",    // empty string -> no text
-        "' ', false",   // space -> no text
-        "'\t', false",  // tab -> no text
-        "' a ', true",  // just a character
-        "'text', true" }, nullValues = { "null" } )
+    @CsvSource(
+            value = {
+                "null, false", // null -> no text
+                "'', false", // empty string -> no text
+                "' ', false", // space -> no text
+                "'\t', false", // tab -> no text
+                "' a ', true", // just a character
+                "'text', true"
+            },
+            nullValues = {"null"})
     // spotless:on
     @DisplayName("hasText should be true only for non-blank strings")
     void hasText_cases(String input, boolean expected) {
@@ -44,11 +52,15 @@ class ValidationUtilTest {
 
     @ParameterizedTest(name = "safeTrim('{0}') => '{1}'")
     // spotless:off
-    @CsvSource( value = { "null, ''",     // null -> empty string
-        "'', ''",       // empty -> empty
-        "' ', ''",      // spaces -> trimmed to empty
-        "' a ', 'a'",
-        "'text', 'text'" }, nullValues = { "null" } )
+    @CsvSource(
+            value = {
+                "null, ''", // null -> empty string
+                "'', ''", // empty -> empty
+                "' ', ''", // spaces -> trimmed to empty
+                "' a ', 'a'",
+                "'text', 'text'"
+            },
+            nullValues = {"null"})
     // spotless:on
     @DisplayName("safeTrim should trim and return empty string for null")
     void safeTrim_cases(String input, String expected) {


### PR DESCRIPTION
By adding the following properties too the `dcat-root.properties`: 

```properties
### Global Behavior
dcat.trace.enabled = false
dcat.format.turtle.availableToUsers = false;
dcat.format.turtle.harvestable = false;
dcat.format.rdfXml.availableToUsers = true;
dcat.format.rdfXml.harvestable = true;
dcat.format.jsonLd.availableToUsers = true;
dcat.format.jsonLd.harvestable = true;
```

you can:

1. determine what format the user see in their export drop down:

<img width="929" height="325" alt="image" src="https://github.com/user-attachments/assets/c0047465-af78-47bb-bbbf-5ee497b1cbed" />

2. determine which format is harvest-able

