### PR TITLE
Sanitizing the IRI

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -70,6 +70,19 @@ dcat.format.jsonLd.availableToUsers = true
 dcat.format.jsonLd.harvestable      = false   # ignored/overridden
 
 ```
+
+### IRI encoding
+
+When an IRI is constructed from the result of a JSONPath expression it is not guarantied to be valid. 
+The most common problem is the existence of whitespace characters, these are automatically replaced by underscores. 
+This makes the resulting IRI more readable than using the percent encoding for whitespace. 
+However, other characters that are not allowed in IRIs are not replaced by default. 
+In order to have the exporter try to encode the 'invalid' IRI, thus making it valid, you need to specify the following property in the `dcat-root.properties` file:
+
+```properties
+dcat.iri.encodeInvalidChars = true
+```
+
 ### relation
 
 The relations describe which entities are relevant in the application profile. Each of the entities can have a file describing that entity.

--- a/application_profiles/AP_NL30/mapping/dcat-root.properties
+++ b/application_profiles/AP_NL30/mapping/dcat-root.properties
@@ -5,7 +5,7 @@
 
 ### Global Behavior
 dcat.trace.enabled = false
-dcat.encode.invalid.iris = false
+dcat.iri.encodeInvalid = false
 # only rdfXml can be harvestable. There is no exporter for turtle and jsonLd -> harvestable ignored for both properties
 dcat.format.turtle.availableToUsers = true;
 dcat.format.turtle.harvestable = false;

--- a/application_profiles/AP_NL30/mapping/dcat-root.properties
+++ b/application_profiles/AP_NL30/mapping/dcat-root.properties
@@ -5,6 +5,7 @@
 
 ### Global Behavior
 dcat.trace.enabled = false
+dcat.encode.invalid.iris = false
 # only rdfXml can be harvestable. There is no exporter for turtle and jsonLd -> harvestable ignored for both properties
 dcat.format.turtle.availableToUsers = true;
 dcat.format.turtle.harvestable = false;

--- a/application_profiles/lightweight/mapping/dcat-root.properties
+++ b/application_profiles/lightweight/mapping/dcat-root.properties
@@ -1,6 +1,6 @@
 
 dcat.trace.enabled = false
-dcat.encode.invalid.iris = false
+dcat.iri.encodeInvalid = false
 # only rdfXml can be harvestable. There is no exporter for turtle and jsonLd -> harvestable ignored for both properties
 dcat.format.turtle.availableToUsers = true;
 dcat.format.turtle.harvestable = false;

--- a/application_profiles/lightweight/mapping/dcat-root.properties
+++ b/application_profiles/lightweight/mapping/dcat-root.properties
@@ -1,5 +1,6 @@
 
 dcat.trace.enabled = false
+dcat.encode.invalid.iris = false
 # only rdfXml can be harvestable. There is no exporter for turtle and jsonLd -> harvestable ignored for both properties
 dcat.format.turtle.availableToUsers = true;
 dcat.format.turtle.harvestable = false;

--- a/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterBase.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/Dcat3ExporterBase.java
@@ -176,7 +176,8 @@ public abstract class Dcat3ExporterBase implements Exporter {
                 ResourceConfig resourceConfig = new ResourceConfigLoader().load(in);
                 elementConfigs.put(element.id(), resourceConfig);
 
-                ResourceMapper resourceMapper = new ResourceMapper(resourceConfig, prefixes, element.typeCurieOrIri());
+                ResourceMapper resourceMapper =
+                        new ResourceMapper(resourceConfig, prefixes, element.typeCurieOrIri(), root.encodeInvalidIris());
 
                 Model elementModel = resourceMapper.build(finder);
 

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoader.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoader.java
@@ -135,7 +135,7 @@ public final class RootConfigLoader {
                     displayNames.put(format, raw.trim());
                 }
             } else {
-                boolean value = parseBooleanDefaultTrue(raw); // parse robustly; default TRUE if missing
+                boolean value = safeBoolean(raw, true); // parse robustly; default TRUE if missing
                 if ("availableToUsers".equals(flag)) {
                     availableToUsers.put(format, value);
                 } else {
@@ -160,12 +160,11 @@ public final class RootConfigLoader {
     }
 
     /**
-     * Robust boolean parsing that defaults to TRUE for missing values, trims whitespace,
-     * ignores a trailing semicolon (e.g., "true;"), and uses Boolean.parseBoolean on
-     * the cleaned token.
+     * Robust boolean parsing: - null -> defaultValue - trims whitespace - ignores a trailing
+     * semicolon (e.g., "true;") - uses Boolean.parseBoolean on the cleaned token
      */
-    private static boolean parseBooleanDefaultTrue(String raw) {
-        if (raw == null) return true;
+    private static boolean safeBoolean(String raw, boolean defaultValue) {
+        if (raw == null) return defaultValue;
         String cleaned = raw.trim();
         if (cleaned.endsWith(";"))
             cleaned = cleaned.substring(0, cleaned.length() - 1).trim();

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoader.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoader.java
@@ -55,6 +55,8 @@ public final class RootConfigLoader {
 
     private static RootConfig parse(Properties properties, Path baseDir) {
         boolean trace = Boolean.parseBoolean(properties.getProperty("dcat.trace.enabled", "false"));
+        boolean encodeInvalidIris =
+                Boolean.parseBoolean(properties.getProperty("dcat.iri.encodeInvalidChars", "false"));
 
         // prefixes.*
         Map<String, String> prefixes = new LinkedHashMap<>();
@@ -107,7 +109,7 @@ public final class RootConfigLoader {
         // dcat.format.<format>.<flag> -> defaults TRUE on absence
         Map<String, FormatFlags> formats = parseFormats(properties);
 
-        return new RootConfig(trace, prefixes, elements, relations, formats, baseDir);
+        return new RootConfig(trace, encodeInvalidIris, prefixes, elements, relations, formats, baseDir);
     }
 
     /** Parse dcat.format.* flags, defaulting to TRUE when a flag is absent. */
@@ -133,7 +135,7 @@ public final class RootConfigLoader {
                     displayNames.put(format, raw.trim());
                 }
             } else {
-                boolean value = safeBoolean(raw, true); // parse robustly; default TRUE if missing
+                boolean value = parseBooleanDefaultTrue(raw); // parse robustly; default TRUE if missing
                 if ("availableToUsers".equals(flag)) {
                     availableToUsers.put(format, value);
                 } else {
@@ -158,11 +160,12 @@ public final class RootConfigLoader {
     }
 
     /**
-     * Robust boolean parsing: - null -> defaultValue - trims whitespace - ignores a trailing
-     * semicolon (e.g., "true;") - uses Boolean.parseBoolean on the cleaned token
+     * Robust boolean parsing that defaults to TRUE for missing values, trims whitespace,
+     * ignores a trailing semicolon (e.g., "true;"), and uses Boolean.parseBoolean on
+     * the cleaned token.
      */
-    private static boolean safeBoolean(String raw, boolean defaultValue) {
-        if (raw == null) return defaultValue;
+    private static boolean parseBooleanDefaultTrue(String raw) {
+        if (raw == null) return true;
         String cleaned = raw.trim();
         if (cleaned.endsWith(";"))
             cleaned = cleaned.substring(0, cleaned.length() - 1).trim();

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/model/RootConfig.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/model/RootConfig.java
@@ -5,10 +5,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
+ * @param encodeInvalidIris Whether invalid IRIs should be percent-encoded during export
  * @param baseDir Directory of the root file; used to resolve element files relative to it
  */
 public record RootConfig(
         boolean trace,
+        boolean encodeInvalidIris,
         Map<String, String> prefixes,
         List<Element> elements,
         List<Relation> relations,

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixer.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixer.java
@@ -3,13 +3,37 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.*;
 
 public class IRIFixer {
-    // RFC 3986 Appendix B — splits ANY string into components, never throws
+    /**
+     * RFC 3986 Appendix B splitter.
+     *
+     * <p>Example for {@code https://user:pass@example.org:8443/catalog/dataset?id=42#section-2}:
+     *
+     * <ul>
+     *   <li>scheme = {@code https}</li>
+     *   <li>authority = {@code user:pass@example.org:8443}</li>
+     *   <li>path = {@code /catalog/dataset}</li>
+     *   <li>query = {@code id=42}</li>
+     *   <li>fragment = {@code section-2}</li>
+     * </ul>
+     *
+     * <p>The capturing groups used in this class are:
+     *
+     * <ul>
+     *   <li>group 2 = scheme</li>
+     *   <li>group 4 = authority</li>
+     *   <li>group 5 = path</li>
+     *   <li>group 7 = query</li>
+     *   <li>group 9 = fragment</li>
+     * </ul>
+     */
     private static final Pattern SPLIT = Pattern.compile(
             "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
 
     public static String buildValidUri(String raw) {
         Matcher m = SPLIT.matcher(raw);
-        m.matches();
+        if (!m.matches()) {
+            return raw;
+        }
 
         String scheme    = m.group(2);
         String authority = m.group(4);
@@ -27,21 +51,59 @@ public class IRIFixer {
         return sb.toString();
     }
 
+    public static String buildValidIri(String raw) {
+        Matcher m = SPLIT.matcher(raw);
+        if (!m.matches()) {
+            return raw;
+        }
+
+        String scheme    = m.group(2);
+        String authority = m.group(4);
+        String path      = m.group(5);
+        String query     = m.group(7);
+        String fragment  = m.group(9);
+
+        StringBuilder sb = new StringBuilder();
+        if (scheme != null)    sb.append(scheme).append(":");
+        if (authority != null) sb.append("//").append(encodeIriAuthority(authority));
+        if (path != null)      sb.append(encodeIriPath(path));
+        if (query != null)     sb.append("?").append(encodeIriQueryOrFragment(query));
+        if (fragment != null)  sb.append("#").append(encodeIriQueryOrFragment(fragment));
+
+        return sb.toString();
+    }
+
     // --- IRI validation ---
 
     /**
      * Checks if the given string is a valid URI according to RFC 3986.
-     * A valid IRI must have a scheme and be well-formed.
+     * A valid URI must have a scheme and be well-formed.
+     *
+     * @param uri the URI string to validate
+     * @return true if the URI is valid, false otherwise
+     */
+    public static boolean isValidUri(String uri) {
+        return isValidIdentifier(uri, false);
+    }
+
+    /**
+     * Checks if the given string is a valid IRI according to RFC 3987.
+     * A valid IRI must have a scheme and may contain legal Unicode code points
+     * in its authority, path, query, and fragment components.
      *
      * @param iri the IRI string to validate
      * @return true if the IRI is valid, false otherwise
      */
-    public static boolean isValidUri(String iri) {
-        if (iri == null || iri.trim().isEmpty()) {
+    public static boolean isValidIri(String iri) {
+        return isValidIdentifier(iri, true);
+    }
+
+    private static boolean isValidIdentifier(String value, boolean allowIriChars) {
+        if (value == null || value.trim().isEmpty()) {
             return false;
         }
 
-        Matcher m = SPLIT.matcher(iri);
+        Matcher m = SPLIT.matcher(value);
         if (!m.matches()) {
             return false;
         }
@@ -69,28 +131,21 @@ public class IRIFixer {
         }
 
         // Path should be non-empty (for most URIs) or authority should be present
-        if ((path == null || path.isEmpty()) && (authority == null || authority.isEmpty())) {
+        if ((path == null || path.isEmpty()) && authority == null) {
             return false;
         }
 
         // Check for illegal characters in each component
-        if (path != null && hasIllegalCharactersInComponent(path, "-._~!$&'()*+,;=:@/")) {
+        if (hasIllegalCharactersInComponent(path, "-._~!$&'()*+,;=:@/", allowIriChars)) {
             return false;
         }
-        if (query != null && hasIllegalCharactersInComponent(query, "-._~!$&'()*+,;=:@/?")) {
+        if (hasIllegalCharactersInComponent(query, "-._~!$&'()*+,;=:@/?", allowIriChars)) {
             return false;
         }
-        if (fragment != null && hasIllegalCharactersInComponent(fragment, "-._~!$&'()*+,;=:@/?")) {
+        if (hasIllegalCharactersInComponent(fragment, "-._~!$&'()*+,;=:@/?", allowIriChars)) {
             return false;
         }
-        if (authority != null && hasIllegalCharactersInComponent(authority, "-._~!$&'()*+,;=:@[]")) {
-            return false;
-        }
-        if (scheme != null && !scheme.matches("^[a-zA-Z0-9+.-]*$")) {
-            return false;
-        }
-        
-        return true;
+        return !hasIllegalCharactersInComponent(authority, "-._~!$&'()*+,;=:@[]", allowIriChars);
     }
 
     /**
@@ -98,18 +153,21 @@ public class IRIFixer {
      *
      * @param component the component string to check
      * @param extraSafeChars the extra allowed characters for this component (beyond alphanumeric)
+     * @param allowIriChars whether RFC 3987 Unicode characters are allowed in this component
      * @return true if illegal characters are found, false otherwise
      */
-    private static boolean hasIllegalCharactersInComponent(String component, String extraSafeChars) {
+    private static boolean hasIllegalCharactersInComponent(
+            String component, String extraSafeChars, boolean allowIriChars) {
         if (component == null || component.isEmpty()) {
             return false;
         }
 
         for (int i = 0; i < component.length(); i++) {
-            char c = component.charAt(i);
+            int cp = component.codePointAt(i);
+            int charCount = Character.charCount(cp);
 
             // Check for percent-encoding: % must be followed by exactly two hex digits
-            if (c == '%') {
+            if (cp == '%') {
                 // Need exactly 2 characters after %
                 if (i + 3 > component.length()) {
                     return true; // Invalid percent-encoding (incomplete)
@@ -122,13 +180,15 @@ public class IRIFixer {
                 } catch (NumberFormatException e) {
                     return true; // Invalid percent-encoding (not hex digits)
                 }
-            } else if (c > 127) {
-                // Non-ASCII character found without percent-encoding
-                return true;
-            } else if (c < 32 || c == 127) {
+            } else if (cp > 127) {
+                if (!allowIriChars || !isUcschar(cp)) {
+                    return true;
+                }
+                i += charCount - 1;
+            } else if (cp < 32 || cp == 127) {
                 // Control characters are illegal
                 return true;
-            } else if (!Character.isLetterOrDigit(c) && extraSafeChars.indexOf(c) < 0) {
+            } else if (!Character.isLetterOrDigit(cp) && extraSafeChars.indexOf(cp) < 0) {
                 // Character is not alphanumeric and not in the extra safe set
                 return true;
             }
@@ -141,6 +201,9 @@ public class IRIFixer {
     private static String encodePath(String s)      { return pctEncode(s, "-._~!$&'()*+,;=:@/"); }
     private static String encodeAuthority(String s)  { return pctEncode(s, "-._~!$&'()*+,;=:@[]"); }
     private static String encodeQueryOrFragment(String s) { return pctEncode(s, "-._~!$&'()*+,;=:@/?"); }
+    private static String encodeIriPath(String s) { return pctEncodeIriAware(s, "-._~!$&'()*+,;=:@/"); }
+    private static String encodeIriAuthority(String s) { return pctEncodeIriAware(s, "-._~!$&'()*+,;=:@[]"); }
+    private static String encodeIriQueryOrFragment(String s) { return pctEncodeIriAware(s, "-._~!$&'()*+,;=:@/?"); }
 
     private static String pctEncode(String s, String extraSafe) {
         StringBuilder out = new StringBuilder();
@@ -154,6 +217,34 @@ public class IRIFixer {
             } else {
                 out.append('%').append(String.format("%02X", b & 0xFF));
             }
+        }
+        return out.toString();
+    }
+
+    private static boolean isUcschar(int codePoint) {
+        return (codePoint >= 0xA0 && codePoint <= 0xD7FF)
+                || (codePoint >= 0xF900 && codePoint <= 0xFDCF)
+                || (codePoint >= 0xFDF0 && codePoint <= 0xFFEF)
+                || (codePoint >= 0x10000 && codePoint <= 0xEFFFD); // simplified supplementary range
+    }
+
+    private static String pctEncodeIriAware(String s, String asciiSafe) {
+        StringBuilder out = new StringBuilder();
+        int i = 0;
+        while (i < s.length()) {
+            int cp = s.codePointAt(i);
+            int charCount = Character.charCount(cp);
+
+            boolean safe = (cp < 128 && (Character.isLetterOrDigit(cp) || asciiSafe.indexOf(cp) >= 0))
+                    || isUcschar(cp);
+
+            if (safe) {
+                out.appendCodePoint(cp);
+            } else {
+                byte[] bytes = new String(Character.toChars(cp)).getBytes(StandardCharsets.UTF_8);
+                for (byte b : bytes) out.append('%').append(String.format("%02X", b & 0xFF));
+            }
+            i += charCount;
         }
         return out.toString();
     }

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixer.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixer.java
@@ -1,0 +1,162 @@
+package io.gdcc.spi.export.dcat3.config.validate;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.*;
+
+public class IRIFixer {
+    // RFC 3986 Appendix B — splits ANY string into components, never throws
+    private static final Pattern SPLIT = Pattern.compile(
+            "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
+
+    public static String buildValidUri(String raw) {
+        Matcher m = SPLIT.matcher(raw);
+        m.matches();
+
+        String scheme    = m.group(2);
+        String authority = m.group(4);
+        String path      = m.group(5);
+        String query     = m.group(7);
+        String fragment  = m.group(9);
+
+        StringBuilder sb = new StringBuilder();
+        if (scheme != null)    sb.append(scheme).append(":");
+        if (authority != null) sb.append("//").append(encodeAuthority(authority));
+        if (path != null)      sb.append(encodePath(path));
+        if (query != null)     sb.append("?").append(encodeQueryOrFragment(query));
+        if (fragment != null)  sb.append("#").append(encodeQueryOrFragment(fragment));
+
+        return sb.toString();
+    }
+
+    // --- IRI validation ---
+
+    /**
+     * Checks if the given string is a valid IRI according to RFC 3986.
+     * A valid IRI must have a scheme and be well-formed.
+     *
+     * @param iri the IRI string to validate
+     * @return true if the IRI is valid, false otherwise
+     */
+    public static boolean isValidIri(String iri) {
+        if (iri == null || iri.trim().isEmpty()) {
+            return false;
+        }
+
+        Matcher m = SPLIT.matcher(iri);
+        if (!m.matches()) {
+            return false;
+        }
+
+        String scheme = m.group(2);
+        String authority = m.group(4);
+        String path = m.group(5);
+        String query = m.group(7);
+        String fragment = m.group(9);
+
+        // RFC 3986: A URI must have a scheme
+        if (scheme == null || scheme.isEmpty()) {
+            return false;
+        }
+
+        // Scheme must start with letter and contain only alphanumeric, +, -, .
+        if (!scheme.matches("^[a-zA-Z][a-zA-Z0-9+.-]*$")) {
+            return false;
+        }
+
+        // If authority is present, it must be non-empty
+        // If authority is absent, path must be non-empty or absolute
+        if (authority != null && authority.isEmpty()) {
+            return false;
+        }
+
+        // Path should be non-empty (for most URIs) or authority should be present
+        if ((path == null || path.isEmpty()) && (authority == null || authority.isEmpty())) {
+            return false;
+        }
+
+        // Check for illegal characters in each component
+        if (path != null && hasIllegalCharactersInComponent(path, "-._~!$&'()*+,;=:@/")) {
+            return false;
+        }
+        if (query != null && hasIllegalCharactersInComponent(query, "-._~!$&'()*+,;=:@/?")) {
+            return false;
+        }
+        if (fragment != null && hasIllegalCharactersInComponent(fragment, "-._~!$&'()*+,;=:@/?")) {
+            return false;
+        }
+        if (authority != null && hasIllegalCharactersInComponent(authority, "-._~!$&'()*+,;=:@[]")) {
+            return false;
+        }
+        if (scheme != null && !scheme.matches("^[a-zA-Z0-9+.-]*$")) {
+            return false;
+        }
+        
+        return true;
+    }
+
+    /**
+     * Checks if a component contains illegal characters according to its allowed character set.
+     *
+     * @param component the component string to check
+     * @param extraSafeChars the extra allowed characters for this component (beyond alphanumeric)
+     * @return true if illegal characters are found, false otherwise
+     */
+    private static boolean hasIllegalCharactersInComponent(String component, String extraSafeChars) {
+        if (component == null || component.isEmpty()) {
+            return false;
+        }
+
+        for (int i = 0; i < component.length(); i++) {
+            char c = component.charAt(i);
+
+            // Check for percent-encoding: % must be followed by exactly two hex digits
+            if (c == '%') {
+                // Need exactly 2 characters after %
+                if (i + 3 > component.length()) {
+                    return true; // Invalid percent-encoding (incomplete)
+                }
+                try {
+                    String hex = component.substring(i + 1, i + 3);
+                    // Verify both characters are valid hex digits
+                    Integer.parseInt(hex, 16);
+                    i += 2; // Skip the two hex digits
+                } catch (NumberFormatException e) {
+                    return true; // Invalid percent-encoding (not hex digits)
+                }
+            } else if (c > 127) {
+                // Non-ASCII character found without percent-encoding
+                return true;
+            } else if (c < 32 || c == 127) {
+                // Control characters are illegal
+                return true;
+            } else if (!Character.isLetterOrDigit(c) && extraSafeChars.indexOf(c) < 0) {
+                // Character is not alphanumeric and not in the extra safe set
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // --- per-component encoders: allow that component's legal chars, encode the rest ---
+
+    private static String encodePath(String s)      { return pctEncode(s, "-._~!$&'()*+,;=:@/"); }
+    private static String encodeAuthority(String s)  { return pctEncode(s, "-._~!$&'()*+,;=:@[]"); }
+    private static String encodeQueryOrFragment(String s) { return pctEncode(s, "-._~!$&'()*+,;=:@/?"); }
+
+    private static String pctEncode(String s, String extraSafe) {
+        StringBuilder out = new StringBuilder();
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+        for (byte b : bytes) {
+            char c = (char) (b & 0xFF);
+            boolean isAscii = b >= 0; // single-byte ASCII range
+            boolean safe = isAscii && (Character.isLetterOrDigit(c) || extraSafe.indexOf(c) >= 0);
+            if (safe) {
+                out.append(c);
+            } else {
+                out.append('%').append(String.format("%02X", b & 0xFF));
+            }
+        }
+        return out.toString();
+    }
+}
+

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixer.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixer.java
@@ -1,5 +1,4 @@
 package io.gdcc.spi.export.dcat3.config.validate;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.*;
 
@@ -31,13 +30,13 @@ public class IRIFixer {
     // --- IRI validation ---
 
     /**
-     * Checks if the given string is a valid IRI according to RFC 3986.
+     * Checks if the given string is a valid URI according to RFC 3986.
      * A valid IRI must have a scheme and be well-formed.
      *
      * @param iri the IRI string to validate
      * @return true if the IRI is valid, false otherwise
      */
-    public static boolean isValidIri(String iri) {
+    public static boolean isValidUri(String iri) {
         if (iri == null || iri.trim().isEmpty()) {
             return false;
         }

--- a/src/main/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixer.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixer.java
@@ -201,6 +201,7 @@ public class IRIFixer {
     private static String encodePath(String s)      { return pctEncode(s, "-._~!$&'()*+,;=:@/"); }
     private static String encodeAuthority(String s)  { return pctEncode(s, "-._~!$&'()*+,;=:@[]"); }
     private static String encodeQueryOrFragment(String s) { return pctEncode(s, "-._~!$&'()*+,;=:@/?"); }
+    
     private static String encodeIriPath(String s) { return pctEncodeIriAware(s, "-._~!$&'()*+,;=:@/"); }
     private static String encodeIriAuthority(String s) { return pctEncodeIriAware(s, "-._~!$&'()*+,;=:@[]"); }
     private static String encodeIriQueryOrFragment(String s) { return pctEncodeIriAware(s, "-._~!$&'()*+,;=:@/?"); }
@@ -221,6 +222,35 @@ public class IRIFixer {
         return out.toString();
     }
 
+    /**
+     * Checks if the given Unicode code point is a valid UCS character for use in IRIs.
+     *
+     * <p>RFC 3987 defines UCS characters as those Unicode code points that are safe to include
+     * directly in IRIs (International Resource Identifiers) without percent-encoding.
+     * This method validates membership in the allowed UCS character ranges:
+     *
+     * <ul>
+     *   <li>{@code U+00A0..U+D7FF}: Latin supplements, Greek, Cyrillic, CJK, etc.</li>
+     *   <li>{@code U+F900..U+FDCF}: CJK compatibility ideographs</li>
+     *   <li>{@code U+FDF0..U+FFEF}: Arabic presentation forms, half-width forms</li>
+     *   <li>{@code U+10000..U+EFFFD}: Supplementary Multilingual Plane and beyond (including emoji)</li>
+     * </ul>
+     *
+     * <p>Excluded ranges include:
+     *
+     * <ul>
+     *   <li>Control characters ({@code U+0000..U+001F}, {@code U+007F..U+009F})</li>
+     *   <li>Surrogates ({@code U+D800..U+DFFF})</li>
+     *   <li>Noncharacters</li>
+     * </ul>
+     *
+     * <p>Example: {@code café} contains the character {@code é} (U+00E9), which falls in the
+     * first range and is thus a valid UCS character that can appear unencoded in an IRI.
+     *
+     * @param codePoint the Unicode code point to test
+     * @return true if the code point is a valid UCS character, false otherwise
+     * @see <a href="https://tools.ietf.org/html/rfc3987">RFC 3987 - Internationalized Resource Identifiers (IRIs)</a>
+     */
     private static boolean isUcschar(int codePoint) {
         return (codePoint >= 0xA0 && codePoint <= 0xD7FF)
                 || (codePoint >= 0xF900 && codePoint <= 0xFDCF)

--- a/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
@@ -5,6 +5,8 @@ import io.gdcc.spi.export.dcat3.config.model.NodeTemplate;
 import io.gdcc.spi.export.dcat3.config.model.ResourceConfig;
 import io.gdcc.spi.export.dcat3.config.model.Subject;
 import io.gdcc.spi.export.dcat3.config.model.ValueSource;
+import io.gdcc.spi.export.dcat3.config.validate.IRIFixer;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -12,6 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.TypeMapper;
 import org.apache.jena.rdf.model.Literal;
@@ -30,9 +33,14 @@ public class ResourceMapper {
 
     private String sanitizeIri(String iri) {
         // Replace whitespace with underscores, takes care of most issues
-        iri = iri.replaceAll("\\s+", "_"); 
+        iri = iri.replaceAll("\\s+", "_");
+        
         // Try to fix all characters, forcing to URI if successful
         // Maybe make this into an option?
+        // Note that we could have the whitespace percent encoded as well, but we don't. 
+        if (!IRIFixer.isValidIri(iri)) {
+            iri = IRIFixer.buildValidUri(iri);
+        }
         return iri;
     }
     

--- a/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
@@ -30,19 +30,7 @@ public class ResourceMapper {
     private final ResourceConfig resourceConfig;
     private final Prefixes prefixes;
     private final String resourceTypeCurieOrIri;
-
-    private String sanitizeIri(String iri) {
-        // Replace whitespace with underscores, takes care of most issues
-        iri = iri.replaceAll("\\s+", "_");
-        
-        // Try to fix all characters
-        // Maybe make this into an option ( or forcing into Uri)?
-        // Note that we could have the whitespace percent encoded as well, but we don't. 
-        if (!IRIFixer.isValidIri(iri)) { // prevent double encoding
-            iri = IRIFixer.buildValidIri(iri);
-        }
-        return iri;
-    }
+    
     
     public ResourceMapper(ResourceConfig resourceConfig, Prefixes prefixes, String resourceTypeCurieOrIri) {
         this.resourceConfig = resourceConfig;
@@ -298,7 +286,7 @@ public class ResourceMapper {
             return null;
         }
 
-        Resource resource = model.createResource(iri);
+        Resource resource = model.createResource(sanitizeIri(iri));
 
         // Attach nested properties (if any)
         emitNestedProps(model, finder, nodeTemplate, resource);
@@ -477,6 +465,19 @@ public class ResourceMapper {
         return s != null && s.matches("^[a-zA-Z][a-zA-Z0-9+.-]*:.*");
     }
 
+    private String sanitizeIri(String iri) {
+        // Replace whitespace with underscores, takes care of most issues
+        iri = iri.replaceAll("\\s+", "_");
+
+        // Try to fix all characters
+        // Maybe make this into an option ( or forcing into Uri)?
+        // Note that we could have the whitespace percent encoded as well, but we don't. 
+        if (!IRIFixer.isValidIri(iri)) { // prevent double encoding
+            iri = IRIFixer.buildValidIri(iri);
+        }
+        return iri;
+    }
+ 
     private List<RDFNode> resolveLiteralValues(Model model, JaywayJsonFinder finder, ValueSource valueSource) {
         List<String> rawValues = valuesFromSource(finder, valueSource);
         boolean hasInput = !rawValues.isEmpty();

--- a/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
@@ -35,11 +35,11 @@ public class ResourceMapper {
         // Replace whitespace with underscores, takes care of most issues
         iri = iri.replaceAll("\\s+", "_");
         
-        // Try to fix all characters, forcing to URI if successful
-        // Maybe make this into an option?
+        // Try to fix all characters
+        // Maybe make this into an option ( or forcing into Uri)?
         // Note that we could have the whitespace percent encoded as well, but we don't. 
-        if (!IRIFixer.isValidUri(iri)) {
-            iri = IRIFixer.buildValidUri(iri);
+        if (!IRIFixer.isValidIri(iri)) { // prevent double encoding
+            iri = IRIFixer.buildValidIri(iri);
         }
         return iri;
     }

--- a/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
@@ -38,7 +38,7 @@ public class ResourceMapper {
         // Try to fix all characters, forcing to URI if successful
         // Maybe make this into an option?
         // Note that we could have the whitespace percent encoded as well, but we don't. 
-        if (!IRIFixer.isValidIri(iri)) {
+        if (!IRIFixer.isValidUri(iri)) {
             iri = IRIFixer.buildValidUri(iri);
         }
         return iri;

--- a/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
@@ -28,12 +28,20 @@ public class ResourceMapper {
     private final Prefixes prefixes;
     private final String resourceTypeCurieOrIri;
 
+    private String sanitizeIri(String iri) {
+        // Replace whitespace with underscores, takes care of most issues
+        iri = iri.replaceAll("\\s+", "_"); 
+        // Try to fix all characters, forcing to URI if successful
+        // Maybe make this into an option?
+        return iri;
+    }
+    
     public ResourceMapper(ResourceConfig resourceConfig, Prefixes prefixes, String resourceTypeCurieOrIri) {
         this.resourceConfig = resourceConfig;
         this.prefixes = prefixes;
         this.resourceTypeCurieOrIri = resourceTypeCurieOrIri;
     }
-
+    
     public Model build(JaywayJsonFinder finder) {
         Model model = ModelFactory.createDefaultModel();
         model.setNsPrefixes(prefixes.jena());
@@ -101,7 +109,7 @@ public class ResourceMapper {
                     s -> s == null ? "" : s.trim());
         }
 
-        return isBlank(iri) ? model.createResource() : model.createResource(iri);
+        return isBlank(iri) ? model.createResource() : model.createResource(sanitizeIri(iri));
     }
 
     private void addProperty(Model model, Resource subject, JaywayJsonFinder finder, ValueSource valueSource) {

--- a/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
+++ b/src/main/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapper.java
@@ -30,12 +30,21 @@ public class ResourceMapper {
     private final ResourceConfig resourceConfig;
     private final Prefixes prefixes;
     private final String resourceTypeCurieOrIri;
-    
-    
+    private final boolean encodeInvalidIris;
+
     public ResourceMapper(ResourceConfig resourceConfig, Prefixes prefixes, String resourceTypeCurieOrIri) {
+        this(resourceConfig, prefixes, resourceTypeCurieOrIri, true);
+    }
+
+    public ResourceMapper(
+            ResourceConfig resourceConfig,
+            Prefixes prefixes,
+            String resourceTypeCurieOrIri,
+            boolean encodeInvalidIris) {
         this.resourceConfig = resourceConfig;
         this.prefixes = prefixes;
         this.resourceTypeCurieOrIri = resourceTypeCurieOrIri;
+        this.encodeInvalidIris = encodeInvalidIris;
     }
     
     public Model build(JaywayJsonFinder finder) {
@@ -129,6 +138,7 @@ public class ResourceMapper {
                     .map(ResourceMapper::trimToNull)
                     .filter(Objects::nonNull)
                     .filter(ResourceMapper::looksLikeIri)
+                    .map(this::sanitizeIri)
                     .map(model::createResource)
                     .collect(Collectors.toList());
             default -> resolveLiteralValues(model, finder, valueSource);
@@ -471,8 +481,8 @@ public class ResourceMapper {
 
         // Try to fix all characters
         // Maybe make this into an option ( or forcing into Uri)?
-        // Note that we could have the whitespace percent encoded as well, but we don't. 
-        if (!IRIFixer.isValidIri(iri)) { // prevent double encoding
+        // Note that we could have the whitespace percent encoded as well, but we don't.
+        if (encodeInvalidIris && !IRIFixer.isValidIri(iri)) { // prevent double encoding
             iri = IRIFixer.buildValidIri(iri);
         }
         return iri;

--- a/src/test/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoaderTest.java
+++ b/src/test/java/io/gdcc/spi/export/dcat3/config/loader/RootConfigLoaderTest.java
@@ -58,6 +58,7 @@ public class RootConfigLoaderTest {
 
         // Assert: root-level settings
         assertThat(rootConfig.trace()).isTrue();
+        assertThat(rootConfig.encodeInvalidIris()).isFalse();
         assertThat(rootConfig.prefixes())
                 .containsEntry("dcat", "http://www.w3.org/ns/dcat#")
                 .containsEntry("dct", "http://purl.org/dc/terms/");
@@ -321,7 +322,7 @@ public class RootConfigLoaderTest {
         RootConfig rootConfig = RootConfigLoader.load();
 
         // Assert: element ids sorted deterministically
-        assertThat(rootConfig.elements()).extracting(e -> e.id()).containsExactly("alpha", "beta", "zeta");
+        assertThat(rootConfig.elements()).extracting(io.gdcc.spi.export.dcat3.config.model.Element::id).containsExactly("alpha", "beta", "zeta");
 
         // Assert: relations sorted deterministically (subject, predicate, object)
         assertThat(rootConfig.relations())
@@ -358,6 +359,47 @@ public class RootConfigLoaderTest {
         assertThat(rootConfig.formats().get("turtle").displayName()).isEqualTo("DCAT-AP-NL (Turtle)");
         assertThat(rootConfig.formats().get("rdfXml").displayName()).isNull();
         assertThat(rootConfig.formats().get("jsonLd").displayName()).isEqualTo("DCAT-AP-NL (JSON-LD)");
+    }
+
+    @Test
+    void parses_encode_invalid_iris_when_enabled() throws Exception {
+        Path rootFile = temp.resolve("dcat-root-encode-invalid-iris.properties");
+        Files.writeString(
+                rootFile,
+                """
+            dcat.trace.enabled = false
+            dcat.iri.encodeInvalidChars = true
+            element.catalog.id = catalog
+            element.catalog.type = dcat:Catalog
+            element.catalog.file = dcat-catalog.properties
+            """);
+        Files.writeString(temp.resolve("dcat-catalog.properties"), "subject.iri.const = https://example.org/cat");
+
+        System.setProperty(RootConfigLoader.SYS_PROP, rootFile.toString());
+
+        RootConfig rootConfig = RootConfigLoader.load();
+
+        assertThat(rootConfig.encodeInvalidIris()).isTrue();
+    }
+
+    @Test
+    void encode_invalid_iris_defaults_to_false_when_absent() throws Exception {
+        Path rootFile = temp.resolve("dcat-root-default-encode-invalid-iris.properties");
+        Files.writeString(
+                rootFile,
+                """
+            dcat.trace.enabled = false
+            element.catalog.id = catalog
+            element.catalog.type = dcat:Catalog
+            element.catalog.file = dcat-catalog.properties
+            """);
+        Files.writeString(temp.resolve("dcat-catalog.properties"), "subject.iri.const = https://example.org/cat");
+
+        System.setProperty(RootConfigLoader.SYS_PROP, rootFile.toString());
+
+        RootConfig rootConfig = RootConfigLoader.load();
+
+        assertThat(rootConfig.encodeInvalidIris()).isFalse();
     }
 
     // --- helpers ---

--- a/src/test/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixerTest.java
+++ b/src/test/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixerTest.java
@@ -65,7 +65,7 @@ class IRIFixerTest {
     // spotless:on
     @DisplayName("Validate IRI format with component-specific character checking")
     void isValidIri_cases(String iri, boolean expected) {
-        assertThat(IRIFixer.isValidIri(iri)).isEqualTo(expected);
+        assertThat(IRIFixer.isValidUri(iri)).isEqualTo(expected);
     }
 
     @ParameterizedTest(name = "Component illegal chars: path=''{0}'' => {1}")
@@ -81,7 +81,7 @@ class IRIFixerTest {
     @DisplayName("Validate path component with proper encoding")
     void componentPath_validation(String path, boolean shouldBeValid) {
         String uri = "http://example.org/" + path;
-        assertThat(IRIFixer.isValidIri(uri)).isEqualTo(shouldBeValid);
+        assertThat(IRIFixer.isValidUri(uri)).isEqualTo(shouldBeValid);
     }
 
     @ParameterizedTest(name = "Component illegal chars: query=''{0}'' => {1}")
@@ -98,7 +98,7 @@ class IRIFixerTest {
     @DisplayName("Validate query component with proper encoding")
     void componentQuery_validation(String query, boolean shouldBeValid) {
         String uri = "http://example.org/path?" + query;
-        assertThat(IRIFixer.isValidIri(uri)).isEqualTo(shouldBeValid);
+        assertThat(IRIFixer.isValidUri(uri)).isEqualTo(shouldBeValid);
     }
 
     @ParameterizedTest(name = "Component illegal chars: fragment=''{0}'' => {1}")
@@ -115,6 +115,6 @@ class IRIFixerTest {
     @DisplayName("Validate fragment component with proper encoding")
     void componentFragment_validation(String fragment, boolean shouldBeValid) {
         String uri = "http://example.org/path#" + fragment;
-        assertThat(IRIFixer.isValidIri(uri)).isEqualTo(shouldBeValid);
+        assertThat(IRIFixer.isValidUri(uri)).isEqualTo(shouldBeValid);
     }
 }

--- a/src/test/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixerTest.java
+++ b/src/test/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixerTest.java
@@ -1,0 +1,120 @@
+package io.gdcc.spi.export.dcat3.config.validate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class IRIFixerTest {
+
+    @ParameterizedTest(name = "buildValidUri(''{0}'') => ''{1}''")
+    // spotless:off
+    @CsvSource({
+        "http://example.org/simple, http://example.org/simple",
+        "'https://example.org/a path?q=x y#z z', 'https://example.org/a%20path?q=x%20y#z%20z'",
+        "'https://user:pass@[2001:db8::1]:8080/p', 'https://user:pass@[2001:db8::1]:8080/p'",
+        "'urn:uuid:550e8400-e29b-41d4-a716-446655440000', 'urn:uuid:550e8400-e29b-41d4-a716-446655440000'",
+        "'https://example.org/café', 'https://example.org/caf%C3%A9'",
+        "'https://example.org/a%20b', 'https://example.org/a%2520b'",
+        "'', ''"
+    })
+    // spotless:on
+    @DisplayName("Encode URI/IRI components using RFC 3986 safe characters")
+    void buildValidUri_cases(String raw, String expected) {
+        assertThat(IRIFixer.buildValidUri(raw)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "query and fragment keep '/' and '?' in ''{0}''")
+    @CsvSource({
+        "'https://example.org/p?x=/a?b#f/a?b', 'https://example.org/p?x=/a?b#f/a?b'",
+        "'https://example.org/p?x=a b#f g', 'https://example.org/p?x=a%20b#f%20g'"
+    })
+    @DisplayName("Apply query/fragment encoding rules")
+    void buildValidUri_queryAndFragmentCases(String raw, String expected) {
+        assertThat(IRIFixer.buildValidUri(raw)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "isValidIri(''{0}'') => {1}")
+    // spotless:off
+    @CsvSource(
+            value = {
+                "http://example.org/path, true",
+                "https://example.org, true",
+                "urn:uuid:550e8400-e29b-41d4-a716-446655440000, true",
+                "mailto:user@example.org, true",
+                "ftp://ftp.example.org/file.txt, true",
+                "http://example.org:8080/valid, true",
+                "'http://example.org/path/with/slashes', true",
+                "'http://example.org/path?query=a&b=c', true",
+                "'http://example.org/path#fragment/test', true",
+                "null, false",
+                "'', false",
+                "' ', false",
+                "example.org/path, false",
+                "://example.org, false",
+                ":invalid, false",
+                "1invalid:path, false",
+                "http://, false",
+                "'http://example.org/café', false",
+                "'http://example.org/path?query=hello world', false",
+                "'http://example.org/path%2', false",
+                "'http://example.org/path%Z', false"
+            },
+            nullValues = {"null"})
+    // spotless:on
+    @DisplayName("Validate IRI format with component-specific character checking")
+    void isValidIri_cases(String iri, boolean expected) {
+        assertThat(IRIFixer.isValidIri(iri)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "Component illegal chars: path=''{0}'' => {1}")
+    @CsvSource({
+        "'simple/path', true",
+        "'path%20with%20spaces', true",
+        "'path%2Fencoded', true",
+        "'café', false",
+        "'path with spaces', false",
+        "'path%2', false",
+        "'path%ZZ', false"
+    })
+    @DisplayName("Validate path component with proper encoding")
+    void componentPath_validation(String path, boolean shouldBeValid) {
+        String uri = "http://example.org/" + path;
+        assertThat(IRIFixer.isValidIri(uri)).isEqualTo(shouldBeValid);
+    }
+
+    @ParameterizedTest(name = "Component illegal chars: query=''{0}'' => {1}")
+    @CsvSource({
+        "'key=value', true",
+        "'a=1&b=2', true",
+        "'key=value%20with%20encoded', true",
+        "'path/with/slash', true",
+        "'nested?query', true",
+        "'café', false",
+        "'unencoded space', false",
+        "'%2', false"
+    })
+    @DisplayName("Validate query component with proper encoding")
+    void componentQuery_validation(String query, boolean shouldBeValid) {
+        String uri = "http://example.org/path?" + query;
+        assertThat(IRIFixer.isValidIri(uri)).isEqualTo(shouldBeValid);
+    }
+
+    @ParameterizedTest(name = "Component illegal chars: fragment=''{0}'' => {1}")
+    @CsvSource({
+        "'section', true",
+        "'section/subsection', true",
+        "'section?param=value', true",
+        "'section%20encoded', true",
+        "'café', false",
+        "'section with spaces', false",
+        "'%2', false",
+        "'%GG', false"
+    })
+    @DisplayName("Validate fragment component with proper encoding")
+    void componentFragment_validation(String fragment, boolean shouldBeValid) {
+        String uri = "http://example.org/path#" + fragment;
+        assertThat(IRIFixer.isValidIri(uri)).isEqualTo(shouldBeValid);
+    }
+}

--- a/src/test/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixerTest.java
+++ b/src/test/java/io/gdcc/spi/export/dcat3/config/validate/IRIFixerTest.java
@@ -25,6 +25,21 @@ class IRIFixerTest {
         assertThat(IRIFixer.buildValidUri(raw)).isEqualTo(expected);
     }
 
+    @ParameterizedTest(name = "buildValidIri(''{0}'') => ''{1}''")
+    // spotless:off
+    @CsvSource({
+        "'https://example.org/café', 'https://example.org/café'",
+        "'https://example.org/東京?q=naïve#crème brûlée', 'https://example.org/東京?q=naïve#crème%20brûlée'",
+        "'https://example.org/a path?q=x y#z z', 'https://example.org/a%20path?q=x%20y#z%20z'",
+        "'https://example.org/a%20b', 'https://example.org/a%2520b'",
+        "'https://user:pass@[2001:db8::1]:8080/δοκιμή', 'https://user:pass@[2001:db8::1]:8080/δοκιμή'"
+    })
+    // spotless:on
+    @DisplayName("Encode IRI components while preserving UCS characters")
+    void buildValidIri_cases(String raw, String expected) {
+        assertThat(IRIFixer.buildValidIri(raw)).isEqualTo(expected);
+    }
+
     @ParameterizedTest(name = "query and fragment keep '/' and '?' in ''{0}''")
     @CsvSource({
         "'https://example.org/p?x=/a?b#f/a?b', 'https://example.org/p?x=/a?b#f/a?b'",
@@ -35,7 +50,7 @@ class IRIFixerTest {
         assertThat(IRIFixer.buildValidUri(raw)).isEqualTo(expected);
     }
 
-    @ParameterizedTest(name = "isValidIri(''{0}'') => {1}")
+    @ParameterizedTest(name = "isValidUri(''{0}'') => {1}")
     // spotless:off
     @CsvSource(
             value = {
@@ -63,9 +78,32 @@ class IRIFixerTest {
             },
             nullValues = {"null"})
     // spotless:on
-    @DisplayName("Validate IRI format with component-specific character checking")
-    void isValidIri_cases(String iri, boolean expected) {
+    @DisplayName("Validate URI format with component-specific character checking")
+    void isValidUri_cases(String iri, boolean expected) {
         assertThat(IRIFixer.isValidUri(iri)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest(name = "isValidIri(''{0}'') => {1}")
+    // spotless:off
+    @CsvSource(
+            value = {
+                "http://example.org/path, true",
+                "'http://example.org/café', true",
+                "'https://example.org/東京?q=naïve#crème', true",
+                "'https://example.org/δοκιμή?κλειδί=τιμή#ενότητα', true",
+                "'http://example.org/path?query=hello world', false",
+                "'http://example.org/path%2', false",
+                "'http://example.org/path%Z', false",
+                "example.org/path, false",
+                "http://, false",
+                "null, false",
+                "'', false"
+            },
+            nullValues = {"null"})
+    // spotless:on
+    @DisplayName("Validate IRI format with Unicode-aware component checking")
+    void isValidIri_cases(String iri, boolean expected) {
+        assertThat(IRIFixer.isValidIri(iri)).isEqualTo(expected);
     }
 
     @ParameterizedTest(name = "Component illegal chars: path=''{0}'' => {1}")
@@ -82,6 +120,19 @@ class IRIFixerTest {
     void componentPath_validation(String path, boolean shouldBeValid) {
         String uri = "http://example.org/" + path;
         assertThat(IRIFixer.isValidUri(uri)).isEqualTo(shouldBeValid);
+    }
+
+    @ParameterizedTest(name = "IRI path chars: path=''{0}'' => {1}")
+    @CsvSource({
+        "'café', true",
+        "'東京', true",
+        "'path with spaces', false",
+        "'path%2', false"
+    })
+    @DisplayName("Validate IRI path component with Unicode support")
+    void componentPath_iriValidation(String path, boolean shouldBeValid) {
+        String iri = "http://example.org/" + path;
+        assertThat(IRIFixer.isValidIri(iri)).isEqualTo(shouldBeValid);
     }
 
     @ParameterizedTest(name = "Component illegal chars: query=''{0}'' => {1}")
@@ -101,6 +152,19 @@ class IRIFixerTest {
         assertThat(IRIFixer.isValidUri(uri)).isEqualTo(shouldBeValid);
     }
 
+    @ParameterizedTest(name = "IRI query chars: query=''{0}'' => {1}")
+    @CsvSource({
+        "'café', true",
+        "'κλειδί=τιμή', true",
+        "'unencoded space', false",
+        "'%2', false"
+    })
+    @DisplayName("Validate IRI query component with Unicode support")
+    void componentQuery_iriValidation(String query, boolean shouldBeValid) {
+        String iri = "http://example.org/path?" + query;
+        assertThat(IRIFixer.isValidIri(iri)).isEqualTo(shouldBeValid);
+    }
+
     @ParameterizedTest(name = "Component illegal chars: fragment=''{0}'' => {1}")
     @CsvSource({
         "'section', true",
@@ -116,5 +180,18 @@ class IRIFixerTest {
     void componentFragment_validation(String fragment, boolean shouldBeValid) {
         String uri = "http://example.org/path#" + fragment;
         assertThat(IRIFixer.isValidUri(uri)).isEqualTo(shouldBeValid);
+    }
+
+    @ParameterizedTest(name = "IRI fragment chars: fragment=''{0}'' => {1}")
+    @CsvSource({
+        "'café', true",
+        "'節', true",
+        "'section with spaces', false",
+        "'%GG', false"
+    })
+    @DisplayName("Validate IRI fragment component with Unicode support")
+    void componentFragment_iriValidation(String fragment, boolean shouldBeValid) {
+        String iri = "http://example.org/path#" + fragment;
+        assertThat(IRIFixer.isValidIri(iri)).isEqualTo(shouldBeValid);
     }
 }

--- a/src/test/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapperTest.java
+++ b/src/test/java/io/gdcc/spi/export/dcat3/mapping/ResourceMapperTest.java
@@ -144,6 +144,89 @@ class ResourceMapperTest {
         assertThat(idStmts.get(0).getObject().asResource().getURI()).isEqualTo("http://example.org/id-iri");
     }
 
+    @Test
+    @DisplayName("subject invalid IRI is encoded only when encodeInvalidIris is enabled")
+    void subject_invalid_iri_respects_encode_invalid_iris_flag() throws Exception {
+        Map<String, String> ns = new LinkedHashMap<>();
+        ns.put("dcat", "http://www.w3.org/ns/dcat#");
+        Prefixes prefixes = new Prefixes(ns);
+
+        ResourceConfig rc = mock(ResourceConfig.class, RETURNS_DEEP_STUBS);
+        when(rc.subject().iriConst()).thenReturn("http://example.org/a|b");
+        when(rc.subject().iriTemplate()).thenReturn(null);
+        when(rc.subject().iriFormat()).thenReturn(null);
+        when(rc.subject().iriJson()).thenReturn(null);
+        when(rc.props()).thenReturn(emptyMap());
+        when(rc.nodes()).thenReturn(emptyMap());
+        when(rc.scopeJson()).thenReturn(null);
+
+        JaywayJsonFinder finder = finderFor("{}");
+
+        ResourceMapper encodeMapper = new ResourceMapper(rc, prefixes, "dcat:Dataset", true);
+        Model encodedModel = encodeMapper.build(finder);
+        Resource encodedSubject = encodedModel.listSubjects().next();
+        assertThat(encodedSubject.getURI()).isEqualTo("http://example.org/a%7Cb");
+
+        ResourceMapper passthroughMapper = new ResourceMapper(rc, prefixes, "dcat:Dataset", false);
+        Model passthroughModel = passthroughMapper.build(finder);
+        Resource passthroughSubject = passthroughModel.listSubjects().next();
+        assertThat(passthroughSubject.getURI()).isEqualTo("http://example.org/a|b");
+    }
+
+    @Test
+    @DisplayName("IRI object values are sanitized only when encodeInvalidIris is enabled")
+    void iri_object_invalid_value_respects_encode_invalid_iris_flag() throws Exception {
+        Map<String, String> ns = new LinkedHashMap<>();
+        ns.put("dcat", "http://www.w3.org/ns/dcat#");
+        ns.put("dct", "http://purl.org/dc/terms/");
+        Prefixes prefixes = new Prefixes(ns);
+
+        ResourceConfig rc = mock(ResourceConfig.class, RETURNS_DEEP_STUBS);
+        when(rc.subject().iriConst()).thenReturn("http://example.org/id");
+        when(rc.subject().iriTemplate()).thenReturn(null);
+        when(rc.subject().iriFormat()).thenReturn(null);
+        when(rc.subject().iriJson()).thenReturn(null);
+
+        ValueSource vsId = mock(ValueSource.class);
+        when(vsId.predicate()).thenReturn("dct:identifier");
+        when(vsId.as()).thenReturn("iri");
+        when(vsId.constValue()).thenReturn("http://example.org/a|b");
+        when(vsId.json()).thenReturn(null);
+        when(vsId.multi()).thenReturn(false);
+        when(vsId.format()).thenReturn(null);
+        when(vsId.lang()).thenReturn(null);
+        when(vsId.datatype()).thenReturn(null);
+        when(vsId.map()).thenReturn(emptyMap());
+        when(vsId.jsonPaths()).thenReturn(emptyList());
+
+        Map<String, ValueSource> props = new LinkedHashMap<>();
+        props.put("identifier", vsId);
+
+        when(rc.props()).thenReturn(props);
+        when(rc.nodes()).thenReturn(emptyMap());
+        when(rc.scopeJson()).thenReturn(null);
+
+        JaywayJsonFinder finder = finderFor("{}");
+
+        ResourceMapper encodeMapper = new ResourceMapper(rc, prefixes, "dcat:Dataset", true);
+        Model encodedModel = encodeMapper.build(finder);
+        List<Statement> encodedStatements = encodedModel.listStatements(
+                        null, encodedModel.getProperty("http://purl.org/dc/terms/identifier"), (RDFNode) null)
+                .toList();
+        assertThat(encodedStatements).hasSize(1);
+        assertThat(encodedStatements.get(0).getObject().asResource().getURI())
+                .isEqualTo("http://example.org/a%7Cb");
+
+        ResourceMapper passthroughMapper = new ResourceMapper(rc, prefixes, "dcat:Dataset", false);
+        Model passthroughModel = passthroughMapper.build(finder);
+        List<Statement> passthroughStatements = passthroughModel.listStatements(
+                        null, passthroughModel.getProperty("http://purl.org/dc/terms/identifier"), (RDFNode) null)
+                .toList();
+        assertThat(passthroughStatements).hasSize(1);
+        assertThat(passthroughStatements.get(0).getObject().asResource().getURI())
+                .isEqualTo("http://example.org/a|b");
+    }
+
     // --- NEW TESTS: iri.format & iri.map on ValueSource and NodeTemplate ---
 
     @Test


### PR DESCRIPTION
Closes [#57](https://github.com/gdcc/exporter-dcat3/issues/57)

Firts it is replacing whitespace with underscores. 
If the result is not a valid IRI, encode all characters except for the unicode letters; keep readabilty that we have with IRI's. 
